### PR TITLE
Relax required_ruby_version to support Ruby 4.0.

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -72,6 +72,7 @@ rspec_task:
       - image: ruby:3.2
       - image: ruby:3.3
       - image: ruby:3.4
+      - image: ruby:4.0
 
   <<: *bundle_cache
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ group :development do
 end
 
 group :audit do
-  gem 'bundler', '~> 2.0'
   gem 'bundler-audit', '~> 0.9.0'
 end
 

--- a/faraday-parse_dates.gemspec
+++ b/faraday-parse_dates.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 3.2', '< 4'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency 'faraday', '~> 2.9.0'
 end

--- a/faraday-parse_dates.gemspec
+++ b/faraday-parse_dates.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'README.md', 'LICENSE.md', 'CHANGELOG.md']
 
-  spec.required_ruby_version = '>= 3.2'
+  spec.required_ruby_version = '>= 3.2', '< 5'
 
   spec.add_dependency 'faraday', '~> 2.9.0'
 end


### PR DESCRIPTION
Based on: https://github.com/lostisland/faraday-multipart/pull/21 :)